### PR TITLE
[build] support for .NET 5.0+

### DIFF
--- a/Runtime/Xamarin.Android.FSharp.ResourceProvider.Runtime.fsproj
+++ b/Runtime/Xamarin.Android.FSharp.ResourceProvider.Runtime.fsproj
@@ -37,15 +37,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.0.0.1\lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.dll</HintPath>
-    </Reference>
+    <PackageReference Include="FSharp.Core" Version="4.0.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <Compile Include="Provider.fs" />
     <Compile Include="AssemblyInfo.fs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.FSharp.targets" />
-  <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.23.4.0.1\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.23.4.0.1\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
 </Project>

--- a/Runtime/packages.config
+++ b/Runtime/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="FSharp.Core" version="4.0.0.1" targetFramework="monoandroid70" />
-</packages>

--- a/Xamarin.Android.FSharp.ResourceProvider.fsproj
+++ b/Xamarin.Android.FSharp.ResourceProvider.fsproj
@@ -1,48 +1,12 @@
-﻿<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{F0B64BEE-BBAA-4A11-94F8-DBE1A9C04D11}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Xamarin.Android.FSharp</RootNamespace>
-    <AssemblyName>Xamarin.Android.FSharp.ResourceProvider</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin</OutputPath>
-    <DefineConstants>DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin</OutputPath>
-    <DefineConstants></DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <GenerateTailCalls>true</GenerateTailCalls>
-    <PlatformTarget></PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup>
-    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(VisualStudioVersion)' == '10.0' OR '$(VisualStudioVersion)' == '11.0'">
-    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="FSharp.Core">
-      <HintPath>packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resource.designer.cs" />
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="ResourceTypeProvider.fs" />
   </ItemGroup>
-  <Import Project="$(FSharpTargetsPath)" />
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,25 +22,18 @@ jobs:
   - checkout: self
     clean: true
 
-  - task: NuGetCommand@2
-    displayName: nuget restore Xamarin.Android.FSharp.ResourceProvider.sln
-    inputs:
-      command: restore
-      restoreSolution: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.sln
-
   - task: MSBuild@1
     displayName: msbuild Xamarin.Android.FSharp.ResourceProvider.sln
     inputs:
       solution: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.sln
-      msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/build.binlog
+      msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/build.binlog
       configuration: Release
-      restoreNugetPackages: true
 
   - task: NuGetCommand@2
     displayName: pack nupkg
     inputs:
       command: pack
-      packagesToPack: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.fsproj
+      packagesToPack: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/bin/
 
   - task: NuGetCommand@2


### PR DESCRIPTION
Trying to build an F# project under .NET 5 fails with:

    error FS3053 : The type provider 'Xamarin.Android.FSharp.ResourceProvider' reported an error : The type provider constructor has thrown an exception: Could not load file or assembly 'System.CodeDom, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified.

We need this library to target `netstandard2.0`, so it will work on
.NET framework, Mono, and .NET Core (.NET 5+). I reworked
`Xamarin.Android.FSharp.ResourceProvider.fsproj` to be
`netstandard2.0`.

This created a new issue when I tried to *use* the package in a .NET 5
project:

    Foo.Android.fsproj : error NU1202: Package Xamarin.Android.FSharp.ResourceProvider 1.0.0.29 is not compatible with net5.0 (net5.0). Package Xamarin.Android.FSharp.ResourceProvider 1.0.0.29 supports:
    Foo.Android.fsproj : error NU1202:   - monoandroid81 (MonoAndroid,Version=v8.1)
    Foo.Android.fsproj : error NU1202:   - netstandard2.0 (.NETStandard,Version=v2.0)

.NET 5.0 seems to prefer `netstandard2.0` over `monoandroid81`, and so
it doesn't know what to do here: hence the error.

I literally, could run this command on the package and it works afterward:

    zip -d Xamarin.Android.FSharp.ResourceProvider.1.0.0.29.nupkg lib/netstandard2.0/Xamarin.Android.Fsharp.ResourceProvider.dll

The fix is to use the `.nuspec` instead of the `.fsproj`:

    -nuget pack Xamarin.Android.FSharp.ResourceProvider.fsproj
    +nuget pack Xamarin.Android.FSharp.ResourceProvider.nuspec

I also made some changes to the Xamarin.Android project (just general
cleanup):

* Migrate from `packages.config` to `@(PackageReference)`
* We can rely on `/restore` now in the build definition.
  `restoreNugetPackages` is deprecated, so we shouldn't use it.
* Removed an `<Import/>` that was unused.