### PR TITLE
[ci] Add YAML build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ jobs:
     inputs:
       solution: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.sln
       msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/build.binlog
+      configuration: Release
       restoreNugetPackages: true
 
   - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,10 @@
 # Xamarin.Android.FSharp.ResourceProvider
 
 trigger:
-  - main
+  - master
 
 pr:
-  - main
+  - master
 
 jobs:
 - job: build
@@ -47,8 +47,7 @@ jobs:
     inputs:
       command: push
       packagesToPush: $(System.DefaultWorkingDirectory)/bin/*.nupkg
-      nuGetFeedType: external
-      publishFeedCredentials: xamarin-impl public feed
+      publishVstsFeed: public/Xamarin.Android
     condition: and(succeeded(), eq(variables['PushToFeed'], 'true'))
 
   - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,59 @@
+# Xamarin.Android.FSharp.ResourceProvider
+
+trigger:
+  - main
+
+pr:
+  - main
+
+jobs:
+- job: build
+  displayName: Build
+  timeoutInMinutes: 60
+  cancelTimeoutInMinutes: 2
+
+  pool:
+    vmImage: macOS-10.15
+
+  workspace:
+    clean: all
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - task: NuGetCommand@2
+    displayName: nuget restore Xamarin.Android.FSharp.ResourceProvider.sln
+    inputs:
+      command: restore
+      restoreSolution: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.sln
+
+  - task: MSBuild@1
+    displayName: msbuild Xamarin.Android.FSharp.ResourceProvider.sln
+    inputs:
+      solution: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.sln
+      msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/build.binlog
+      restoreNugetPackages: true
+
+  - task: NuGetCommand@2
+    displayName: pack nupkg
+    inputs:
+      command: pack
+      packagesToPack: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.fsproj
+      packDestination: $(System.DefaultWorkingDirectory)/bin/
+
+  - task: NuGetCommand@2
+    displayName: push nupkg
+    inputs:
+      command: push
+      packagesToPush: $(System.DefaultWorkingDirectory)/bin/*.nupkg
+      nuGetFeedType: external
+      publishFeedCredentials: xamarin-impl public feed
+    condition: and(succeeded(), eq(variables['PushToFeed'], 'true'))
+
+  - task: PublishPipelineArtifact@1
+    displayName: publish output
+    inputs:
+      targetPath: $(System.DefaultWorkingDirectory)/bin
+      artifactName: Xamarin.Android.FSharp.ResourceProvider
+    condition: succeededOrFailed()


### PR DESCRIPTION
Adds a build pipeline to validate pull requests, and package
and push new nupkg versions to an internal feed for testing.
A queue time variable must be set for a new package version
to be pushed to this feed.

Feed: https://dev.azure.com/xamarin/public/_packaging?_a=feed&feed=Xamarin.Android