### PR TITLE
[build] Set Microsoft metadata for NuGet.org

### DIFF
--- a/AssemblyInfo.fs
+++ b/AssemblyInfo.fs
@@ -3,12 +3,12 @@ open System.Reflection
 
 [<assembly: AssemblyTitle("Xamarin.Android.FSharp.ResourceProvider")>]
 [<assembly: AssemblyDescription("Android type provider for resource IDs")>]
-[<assembly: AssemblyCompany("Xamarin")>]
-[<assembly: AssemblyCopyright("Xamarin")>]
+[<assembly: AssemblyCompany("Microsoft")>]
+[<assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")>]
 
 // The assembly version has the format {Major}.{Minor}.{Build}.{Revision}
 
-[<assembly: AssemblyVersion("1.0.0.28")>]
+[<assembly: AssemblyVersion("1.0.1")>]
 
 //[<assembly: AssemblyDelaySign(false)>]
 //[<assembly: AssemblyKeyFile("")>]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Xamarin.Android.FSharp.ResourceProvider.nuspec
+++ b/Xamarin.Android.FSharp.ResourceProvider.nuspec
@@ -4,18 +4,21 @@
         <id>Xamarin.Android.FSharp.ResourceProvider</id>
         <version>1.0.1</version>
         <title>Xamarin.Android.FSharp.ResourceProvider</title>
-        <authors>Xamarin</authors>
-        <owners>Xamarin</owners>
+        <authors>Microsoft</authors>
+        <owners>Microsoft</owners>
         <references>
           <reference file="Xamarin.Android.FSharp.ResourceProvider.Runtime.dll" />
         </references>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Android resource Type Provider</description>
-        <copyright>MIT License</copyright>
+        <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language>en-US</language>
+        <projectUrl>https://github.com/xamarin/Xamarin.Android.FSharp.ResourceProvider</projectUrl>
+        <license type="file">LICENSE</license>
     </metadata>
     <files>
         <file src="bin/Xamarin.Android.FSharp.ResourceProvider.Runtime.dll" target="lib/monoandroid81/Xamarin.Android.FSharp.ResourceProvider.Runtime.dll" />
         <file src="bin/Xamarin.Android.FSharp.ResourceProvider.dll" target="lib/monoandroid81/Xamarin.Android.FSharp.ResourceProvider.dll" />
+        <file src="LICENSE" target="" />
     </files>
 </package>

--- a/Xamarin.Android.FSharp.ResourceProvider.nuspec
+++ b/Xamarin.Android.FSharp.ResourceProvider.nuspec
@@ -19,6 +19,6 @@
     <files>
         <file src="bin/Xamarin.Android.FSharp.ResourceProvider.Runtime.dll" target="lib/monoandroid81/Xamarin.Android.FSharp.ResourceProvider.Runtime.dll" />
         <file src="bin/Xamarin.Android.FSharp.ResourceProvider.dll" target="lib/monoandroid81/Xamarin.Android.FSharp.ResourceProvider.dll" />
-        <file src="LICENSE" target="" />
+        <file src="LICENSE" />
     </files>
 </package>


### PR DESCRIPTION
We had some invalid/missing metadata and content in the .nupkg file that
was preventing us from publishing an updated version to NuGet.org.