### PR TITLE
Fix provider for MonoAndroid target frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Xamarin.Android.FSharp.ResourceProvider
+
+This project has been deprecated. We recommend migrating to https://github.com/fabulousfx/FSharp.Android.Resource.

--- a/Xamarin.Android.FSharp.ResourceProvider.fsproj
+++ b/Xamarin.Android.FSharp.ResourceProvider.fsproj
@@ -11,5 +11,4 @@
     <Compile Include="ResourceTypeProvider.fs" />
     <EmbeddedResource Include="Resource.designer.cs" />
   </ItemGroup>
-
 </Project>

--- a/Xamarin.Android.FSharp.ResourceProvider.fsproj
+++ b/Xamarin.Android.FSharp.ResourceProvider.fsproj
@@ -1,12 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <RootNamespace>Xamarin.Android.FSharp</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="ResourceTypeProvider.fs" />
     <EmbeddedResource Include="Resource.designer.cs" />
   </ItemGroup>
+
 </Project>

--- a/Xamarin.Android.FSharp.ResourceProvider.nuspec
+++ b/Xamarin.Android.FSharp.ResourceProvider.nuspec
@@ -2,12 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Xamarin.Android.FSharp.ResourceProvider</id>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <title>Xamarin.Android.FSharp.ResourceProvider</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <references>
-          <reference file="Xamarin.Android.FSharp.ResourceProvider.Runtime.dll" />
+          <group targetFramework="MonoAndroid8.1">
+            <reference file="Xamarin.Android.FSharp.ResourceProvider.Runtime.dll" />
+          </group>
         </references>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Android resource Type Provider</description>


### PR DESCRIPTION
We mistakenly broke this project in commit ab48982d, as an SDK style
fsharp project will not auto glob .fs files when compling.

Fix the project by compiling `ResourceTypeProvider.fs` again, however
this will only work for Classic Xamarin.Android projects.

There are [non-trivial issues][0] that prevent `ResourceTypeProvider.fs`
from running on .NET Core (CodeDom compiling, AppDomain usage, etc).

These are not worth fixing at this time, as an alternate solution has
been provided in https://github.com/fabulousfx/FSharp.Android.Resource.

[0]: https://github.com/xamarin/Xamarin.Android.FSharp.ResourceProvider/issues/11#issuecomment-1028793264