### PR TITLE
[ci] Add Windows build job to run CodeQL

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="globalPackagesFolder" value="packages" />
+  </config>
+</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <config>
-    <add key="globalPackagesFolder" value="packages" />
-  </config>
-</configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,17 +17,14 @@ resources:
 variables:
   - group: Xamarin-Secrets
   - group: Xamarin Release
-  - name: Codeql.Enabled
-    value: True
 
 jobs:
 - job: build
-  displayName: Build
+  displayName: Build macOS
   timeoutInMinutes: 60
-  cancelTimeoutInMinutes: 2
 
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-latest
 
   workspace:
     clean: all
@@ -76,3 +73,38 @@ jobs:
   parameters:
     artifactName: Xamarin.Android.FSharp.ResourceProvider
     dependsOn: [ 'build' ]
+
+- job: build_windows
+  displayName: Build Windows
+  timeoutInMinutes: 90
+  pool:
+    vmImage: macOS-latest
+  workspace:
+    clean: all
+  variables:
+  - name: Codeql.Enabled
+    value: true
+  steps:
+  - checkout: self
+    clean: true
+
+  - task: MSBuild@1
+    displayName: msbuild Xamarin.Android.FSharp.ResourceProvider.sln
+    inputs:
+      solution: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.sln
+      msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/build.binlog
+      configuration: Release
+
+  - task: NuGetCommand@2
+    displayName: pack nupkg
+    inputs:
+      command: pack
+      packagesToPack: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.nuspec
+      packDestination: $(System.DefaultWorkingDirectory)/bin/
+
+  - task: PublishBuildArtifacts@1
+    displayName: publish binlog
+    inputs:
+      pathToPublish: $(System.DefaultWorkingDirectory)/bin/build.binlog
+      artifactName: Windows binlog
+    condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,10 @@ jobs:
   - checkout: self
     clean: true
 
+  - task: NuGetToolInstaller@1
+    inputs:
+      versionSpec: 5.x
+
   - task: MSBuild@1
     displayName: msbuild Xamarin.Android.FSharp.ResourceProvider.sln
     inputs:
@@ -88,9 +92,13 @@ jobs:
   - checkout: self
     clean: true
 
+  - task: NuGetToolInstaller@1
+    inputs:
+      versionSpec: 5.x
+
   - task: CodeQL3000Init@0
     displayName: CodeQL 3000 Init
-    condition: and(succeeded(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cqltest'))
+    #condition: and(succeeded(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cqltest'))
 
   - task: MSBuild@1
     displayName: msbuild Xamarin.Android.FSharp.ResourceProvider.sln
@@ -108,7 +116,8 @@ jobs:
 
   - task: CodeQL3000Finalize@0
     displayName: CodeQL 3000 Finalize
-    condition: and(succeededOrFailed(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cqltest'))
+    condition: succeededOrFailed()
+    #condition: and(succeededOrFailed(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cqltest'))
 
   - task: PublishBuildArtifacts@1
     displayName: publish binlog

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,10 @@ jobs:
   - checkout: self
     clean: true
 
+  - task: CodeQL3000Init@0
+    displayName: CodeQL 3000 Init
+    condition: and(succeeded(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cqltest'))
+
   - task: MSBuild@1
     displayName: msbuild Xamarin.Android.FSharp.ResourceProvider.sln
     inputs:
@@ -101,6 +105,10 @@ jobs:
       command: pack
       packagesToPack: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/bin/
+
+  - task: CodeQL3000Finalize@0
+    displayName: CodeQL 3000 Finalize
+    condition: and(succeededOrFailed(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cqltest'))
 
   - task: PublishBuildArtifacts@1
     displayName: publish binlog

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,21 +88,12 @@ jobs:
   - checkout: self
     clean: true
 
-  - task: CodeQL3000Init@0
-    displayName: CodeQL 3000 Init
-    #condition: and(succeeded(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cqltest'))
-
   - task: MSBuild@1
     displayName: msbuild Xamarin.Android.FSharp.ResourceProvider.sln
     inputs:
       solution: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.sln
       msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/build.binlog
       configuration: Release
-
-  - task: CodeQL3000Finalize@0
-    displayName: CodeQL 3000 Finalize
-    condition: succeededOrFailed()
-    #condition: and(succeededOrFailed(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cqltest'))
 
   - task: PublishBuildArtifacts@1
     displayName: publish binlog

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
   displayName: Build Windows
   timeoutInMinutes: 90
   pool:
-    vmImage: macOS-latest
+    vmImage: windows-latest
   workspace:
     clean: all
   variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,10 +33,6 @@ jobs:
   - checkout: self
     clean: true
 
-  - task: NuGetToolInstaller@1
-    inputs:
-      versionSpec: 6.x
-
   - task: MSBuild@1
     displayName: msbuild Xamarin.Android.FSharp.ResourceProvider.sln
     inputs:
@@ -92,10 +88,6 @@ jobs:
   - checkout: self
     clean: true
 
-  - task: NuGetToolInstaller@1
-    inputs:
-      versionSpec: 6.x
-
   - task: CodeQL3000Init@0
     displayName: CodeQL 3000 Init
     #condition: and(succeeded(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cqltest'))
@@ -106,13 +98,6 @@ jobs:
       solution: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.sln
       msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/build.binlog
       configuration: Release
-
-  - task: NuGetCommand@2
-    displayName: pack nupkg
-    inputs:
-      command: pack
-      packagesToPack: $(System.DefaultWorkingDirectory)/Xamarin.Android.FSharp.ResourceProvider.nuspec
-      packDestination: $(System.DefaultWorkingDirectory)/bin/
 
   - task: CodeQL3000Finalize@0
     displayName: CodeQL 3000 Finalize

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
 
   - task: NuGetToolInstaller@1
     inputs:
-      versionSpec: 5.x
+      versionSpec: 6.x
 
   - task: MSBuild@1
     displayName: msbuild Xamarin.Android.FSharp.ResourceProvider.sln
@@ -94,7 +94,7 @@ jobs:
 
   - task: NuGetToolInstaller@1
     inputs:
-      versionSpec: 5.x
+      versionSpec: 6.x
 
   - task: CodeQL3000Init@0
     displayName: CodeQL 3000 Init

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
   displayName: Build Windows
   timeoutInMinutes: 90
   pool:
-    vmImage: windows-latest
+    vmImage: windows-2019
   workspace:
     clean: all
   variables:


### PR DESCRIPTION
The project will now build on both macOS and Windows, but CodeQL will
only run during the Windows job.

This fixes a build failure that would occur on macOS when CodeQL was
enabled.